### PR TITLE
Set Java 1.7 as the minimum version to compile against

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,20 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build> 
+  
   <profiles>
     <profile>
       <id>release</id>


### PR DESCRIPTION
## Status
**READY**

## Description
The minimum required JDK version to for compilation and JRE version for execution is 1.7. ([Issue](https://github.com/onelogin/onelogin-java-sdk/issues/11))

## Impacted Areas in Application
List general components of the application that this PR will affect: