### PR TITLE
Allow setting client ID, secret and region programmatically

### DIFF
--- a/src/main/java/com/onelogin/sdk/conn/Client.java
+++ b/src/main/java/com/onelogin/sdk/conn/Client.java
@@ -131,7 +131,7 @@ public class Client {
 	public Client() throws IOException, Error {
 		this(1000);
 	}
-	
+
     public Client(String clientID, String clientSecret, String region) {
         this.settings = new Settings(clientID, clientSecret, region);
         this.userAgent = CUSTOM_USER_AGENT;

--- a/src/main/java/com/onelogin/sdk/conn/Client.java
+++ b/src/main/java/com/onelogin/sdk/conn/Client.java
@@ -132,11 +132,11 @@ public class Client {
 		this(1000);
 	}
 
-    public Client(String clientID, String clientSecret, String region) {
-        this.settings = new Settings(clientID, clientSecret, region);
-        this.userAgent = CUSTOM_USER_AGENT;
-        this.maxResults = 1000;
-    }
+	public Client(String clientID, String clientSecret, String region) {
+		this.settings = new Settings(clientID, clientSecret, region);
+		this.userAgent = CUSTOM_USER_AGENT;
+		this.maxResults = 1000;
+	}
 
 	////////////////////////////////
 	//  OAuth 2.0 Tokens Methods  //

--- a/src/main/java/com/onelogin/sdk/conn/Client.java
+++ b/src/main/java/com/onelogin/sdk/conn/Client.java
@@ -131,6 +131,12 @@ public class Client {
 	public Client() throws IOException, Error {
 		this(1000);
 	}
+	
+    public Client(String clientID, String clientSecret, String region) {
+        this.settings = new Settings(clientID, clientSecret, region);
+        this.userAgent = CUSTOM_USER_AGENT;
+        this.maxResults = 1000;
+    }
 
 	////////////////////////////////
 	//  OAuth 2.0 Tokens Methods  //

--- a/src/main/java/com/onelogin/sdk/util/Settings.java
+++ b/src/main/java/com/onelogin/sdk/util/Settings.java
@@ -47,6 +47,12 @@ public class Settings {
 		    this.region = regionValue;
 		}
 	}
+	
+	public Settings(String clientID, String clientSecret, String region){
+	    this.clientID = clientID;
+	    this.clientSecret = clientSecret;
+	    this.region = region;
+	}
 
 	public String getClientId() {
 		return clientID;

--- a/src/test/java/com/onelogin/sdk/conn/TestClientSettings.java
+++ b/src/test/java/com/onelogin/sdk/conn/TestClientSettings.java
@@ -11,17 +11,17 @@ import com.onelogin.sdk.exception.Error;
 import com.onelogin.sdk.util.Settings;
 
 public class TestClientSettings {
-    @Test
-    public void testValidSettings() throws IOException, Error, OAuthSystemException, OAuthProblemException, URISyntaxException {
-        Settings settings = new Settings();
-        Client client = new Client(settings.getClientId(), settings.getClientSecret(), settings.getRegion());
-        client.getUsers(1);
-    }
+	@Test
+	public void testValidSettings() throws IOException, Error, OAuthSystemException, OAuthProblemException, URISyntaxException {
+		Settings settings = new Settings();
+		Client client = new Client(settings.getClientId(), settings.getClientSecret(), settings.getRegion());
+		client.getUsers(1);
+	}
 
-    @Test(expected = OAuthProblemException.class)
-    public void testInvalidSettings() throws IOException, Error, OAuthSystemException, OAuthProblemException, URISyntaxException {
-        Settings settings = new Settings();
-        Client client = new Client(settings.getClientId(), "badClientSecret", settings.getRegion());
-        client.getUsers(1);
-    }
+	@Test(expected = OAuthProblemException.class)
+	public void testInvalidSettings() throws IOException, Error, OAuthSystemException, OAuthProblemException, URISyntaxException {
+		Settings settings = new Settings();
+		Client client = new Client(settings.getClientId(), "badClientSecret", settings.getRegion());
+		client.getUsers(1);
+	}
 }

--- a/src/test/java/com/onelogin/sdk/conn/TestClientSettings.java
+++ b/src/test/java/com/onelogin/sdk/conn/TestClientSettings.java
@@ -1,0 +1,27 @@
+package com.onelogin.sdk.conn;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.junit.Test;
+
+import com.onelogin.sdk.exception.Error;
+import com.onelogin.sdk.util.Settings;
+
+public class TestClientSettings {
+    @Test
+    public void testValidSettings() throws IOException, Error, OAuthSystemException, OAuthProblemException, URISyntaxException {
+        Settings settings = new Settings();
+        Client client = new Client(settings.getClientId(), settings.getClientSecret(), settings.getRegion());
+        client.getUsers(1);
+    }
+
+    @Test(expected = OAuthProblemException.class)
+    public void testInvalidSettings() throws IOException, Error, OAuthSystemException, OAuthProblemException, URISyntaxException {
+        Settings settings = new Settings();
+        Client client = new Client(settings.getClientId(), "badClientSecret", settings.getRegion());
+        client.getUsers(1);
+    }
+}

--- a/src/test/java/com/onelogin/sdk/model/TestUser.java
+++ b/src/test/java/com/onelogin/sdk/model/TestUser.java
@@ -8,21 +8,21 @@ import org.junit.Test;
 
 public class TestUser {
 
-    @Test
-    public void testReadingCustomFields() {
-        // Data array
-        String jsonBody = "[{\"activated_at\":null,\"created_at\":\"2018-04-22T13:47:46.319Z\",\"email\":\"mohamed.gelbana@incorta.com\",\"username\":null,\"firstname\":\"Mohamed\",\"group_id\":null,\"id\":39027240,\"invalid_login_attempts\":null,\"invitation_sent_at\":\"2018-04-22T13:47:46.064Z\",\"last_login\":\"2018-04-22T13:49:11.090Z\",\"lastname\":\"Gelbana\",\"locked_until\":null,\"comment\":null,\"openid_name\":\"mohamed.gelbana\",\"locale_code\":null,\"password_changed_at\":\"2018-04-22T13:48:29.663Z\",\"phone\":null,\"status\":1,\"updated_at\":\"2018-04-22T13:49:11.414Z\",\"distinguished_name\":null,\"external_id\":null,\"directory_id\":null,\"member_of\":null,\"samaccountname\":null,\"userprincipalname\":null,\"manager_ad_id\":null,\"role_id\":[215481],\"company\":null,\"department\":null,\"title\":null,\"state\":1,\"trusted_idp_id\":null},{\"activated_at\":null,\"created_at\":\"2018-04-22T14:21:26.910Z\",\"email\":\"mohamed.gelbana_test@incorta.com\",\"username\":\"123!@#\",\"firstname\":\"Mohamed\",\"group_id\":null,\"id\":39027246,\"invalid_login_attempts\":null,\"invitation_sent_at\":null,\"last_login\":null,\"lastname\":\"Gelbana\",\"locked_until\":null,\"comment\":\"\",\"openid_name\":\"mohamed.gelbana_test\",\"locale_code\":null,\"password_changed_at\":null,\"phone\":\"+201004273399\",\"status\":1,\"updated_at\":\"2018-04-22T14:55:00.906Z\",\"distinguished_name\":null,\"external_id\":null,\"directory_id\":null,\"member_of\":null,\"samaccountname\":null,\"userprincipalname\":null,\"manager_ad_id\":null,\"role_id\":null,\"company\":\"Incorta\",\"department\":\"Engineering\",\"title\":\"Sr. Software Engineer\",\"state\":1,\"trusted_idp_id\":null,\"custom_attributes\":{\"custAttribute1\":\"value1\",\"custAttribute2\":\"value2\"}}]";
+	@Test
+	public void testReadingCustomFields() {
+		// Data array
+		String jsonBody = "[{\"activated_at\":null,\"created_at\":\"2018-04-22T13:47:46.319Z\",\"email\":\"mohamed.gelbana@incorta.com\",\"username\":null,\"firstname\":\"Mohamed\",\"group_id\":null,\"id\":39027240,\"invalid_login_attempts\":null,\"invitation_sent_at\":\"2018-04-22T13:47:46.064Z\",\"last_login\":\"2018-04-22T13:49:11.090Z\",\"lastname\":\"Gelbana\",\"locked_until\":null,\"comment\":null,\"openid_name\":\"mohamed.gelbana\",\"locale_code\":null,\"password_changed_at\":\"2018-04-22T13:48:29.663Z\",\"phone\":null,\"status\":1,\"updated_at\":\"2018-04-22T13:49:11.414Z\",\"distinguished_name\":null,\"external_id\":null,\"directory_id\":null,\"member_of\":null,\"samaccountname\":null,\"userprincipalname\":null,\"manager_ad_id\":null,\"role_id\":[215481],\"company\":null,\"department\":null,\"title\":null,\"state\":1,\"trusted_idp_id\":null},{\"activated_at\":null,\"created_at\":\"2018-04-22T14:21:26.910Z\",\"email\":\"mohamed.gelbana_test@incorta.com\",\"username\":\"123!@#\",\"firstname\":\"Mohamed\",\"group_id\":null,\"id\":39027246,\"invalid_login_attempts\":null,\"invitation_sent_at\":null,\"last_login\":null,\"lastname\":\"Gelbana\",\"locked_until\":null,\"comment\":\"\",\"openid_name\":\"mohamed.gelbana_test\",\"locale_code\":null,\"password_changed_at\":null,\"phone\":\"+201004273399\",\"status\":1,\"updated_at\":\"2018-04-22T14:55:00.906Z\",\"distinguished_name\":null,\"external_id\":null,\"directory_id\":null,\"member_of\":null,\"samaccountname\":null,\"userprincipalname\":null,\"manager_ad_id\":null,\"role_id\":null,\"company\":\"Incorta\",\"department\":\"Engineering\",\"title\":\"Sr. Software Engineer\",\"state\":1,\"trusted_idp_id\":null,\"custom_attributes\":{\"custAttribute1\":\"value1\",\"custAttribute2\":\"value2\"}}]";
 
-        JSONArray jsonArray = new JSONArray(jsonBody);
+		JSONArray jsonArray = new JSONArray(jsonBody);
 
-        User user = new User(jsonArray.getJSONObject(0));
-        Map attributes = user.getUserCustomAttributes();
-        Assert.assertTrue("User isn't expected to have custom attributes", attributes == null || attributes.isEmpty());
+		User user = new User(jsonArray.getJSONObject(0));
+		Map attributes = user.getUserCustomAttributes();
+		Assert.assertTrue("User isn't expected to have custom attributes", attributes == null || attributes.isEmpty());
 
-        user = new User(jsonArray.getJSONObject(1));
-        attributes = user.getUserCustomAttributes();
-        Assert.assertTrue("User is expected to have 2 custom attributes", attributes.size() == 2);
-        Assert.assertEquals("Attribute custAttribute1 should have a value of 'value1'", "value1", attributes.get("custAttribute1"));
-        Assert.assertEquals("Attribute custAttribute1 should have a value of 'value2'", "value2", attributes.get("custAttribute2"));
-    }
+		user = new User(jsonArray.getJSONObject(1));
+		attributes = user.getUserCustomAttributes();
+		Assert.assertTrue("User is expected to have 2 custom attributes", attributes.size() == 2);
+		Assert.assertEquals("Attribute custAttribute1 should have a value of 'value1'", "value1", attributes.get("custAttribute1"));
+		Assert.assertEquals("Attribute custAttribute1 should have a value of 'value2'", "value2", attributes.get("custAttribute2"));
+	}
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Allow setting client ID, secret and region programmatically. ([Issue](https://github.com/onelogin/onelogin-java-sdk/issues/14))


## Todos
- [x] Tests